### PR TITLE
add account to somejwt sample

### DIFF
--- a/sample/index.mjs
+++ b/sample/index.mjs
@@ -6,5 +6,6 @@ const xumm1 = new Xumm('apikey', 'apisecret');
 console.log('ping', await xumm1.ping())
 
 const xumm2 = new Xumm('somejwt');
+console.log('account', await xumm2.user?.account);
 console.log('jwt', await xumm2.environment.jwt)
 console.log('ping', await xumm2.ping())


### PR DESCRIPTION
It would be preferable to have a sample regarding user information in the case of cli+jwt.

I'm not sure if it is intended that the value of user is not currently retrieved.